### PR TITLE
Update install-deb.sh

### DIFF
--- a/install-deb.sh
+++ b/install-deb.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # a simple install script for sampctl
 
-ARCH=$(uname -p)
+ARCH=$(uname -m)
 PATTERN="browser_download_url.*386\.deb"
 
 if [ $ARCH = "x86_64" ]; then


### PR DESCRIPTION
On Debian and its derivatives (less Ubuntu), `uname -p` gives `unknown`.

`uname -m` should always give the same value as `uname -p` where it is available.