### PR TITLE
Binary compatibility of different multiplayer versions

### DIFF
--- a/runtime/ensure.go
+++ b/runtime/ensure.go
@@ -63,13 +63,13 @@ func Ensure(ctx context.Context, gh *github.Client, cfg *types.Runtime, noCache 
 func EnsureBinaries(cacheDir string, cfg types.Runtime) (err error) {
 	missing := false
 
-	if !util.Exists(filepath.Join(cfg.WorkingDir, getNpcBinary(cfg.Platform))) {
+	if !util.Exists(filepath.Join(cfg.WorkingDir, getNpcBinary(cacheDir, cfg.Version, cfg.Platform))) {
 		missing = true
 	}
-	if !util.Exists(filepath.Join(cfg.WorkingDir, getAnnounceBinary(cfg.Platform))) {
+	if !util.Exists(filepath.Join(cfg.WorkingDir, getAnnounceBinary(cacheDir, cfg.Version, cfg.Platform))) {
 		missing = true
 	}
-	if !util.Exists(filepath.Join(cfg.WorkingDir, getServerBinary(cfg.Platform))) {
+	if !util.Exists(filepath.Join(cfg.WorkingDir, getServerBinary(cacheDir, cfg.Version, cfg.Platform))) {
 		missing = true
 	}
 

--- a/runtime/resource.go
+++ b/runtime/resource.go
@@ -4,6 +4,7 @@ import (
 	"crypto/md5" //nolint:gas
 	"encoding/hex"
 	"io/ioutil"
+	"strings"
 
 	"github.com/Southclaws/sampctl/download"
 	"github.com/Southclaws/sampctl/types"
@@ -26,37 +27,97 @@ import (
 // 	return false
 // }
 
-func getServerBinary(platform string) string {
-	switch platform {
-	case "windows":
-		return "samp-server.exe"
-	case "linux", "darwin":
-		return "samp03svr"
-	default:
-		return ""
+func getServerBinary(cacheDir, version, platform string) (binary string) {
+	pkg, err := FindPackage(cacheDir, version)
+	if err != nil {
+		return
 	}
+	
+	var (
+		paths map[string]string
+		part string
+	)
+	switch platform {
+		case "windows":
+			paths = pkg.Win32Paths
+			part = "samp-server"
+		case "linux", "darwin":
+			paths = pkg.LinuxPaths
+			part = "samp03svr"
+		default:
+			return
+	}
+	
+	for _, destination := range paths {
+		if strings.Contains(destination, part) {
+			binary = destination
+			break
+		}
+	}
+	
+	return
 }
 
-func getNpcBinary(platform string) string {
-	switch platform {
-	case "windows":
-		return "samp-npc.exe"
-	case "linux", "darwin":
-		return "samp-npc"
-	default:
-		return ""
+func getNpcBinary(cacheDir, version, platform string) (binary string) {
+	pkg, err := FindPackage(cacheDir, version)
+	if err != nil {
+		return
 	}
+	
+	var (
+		paths map[string]string
+		part string
+	)
+	switch platform {
+		case "windows":
+			paths = pkg.Win32Paths
+			part = "npc"
+		case "linux", "darwin":
+			paths = pkg.LinuxPaths
+			part = "npc"
+		default:
+			return
+	}
+	
+	for _, destination := range paths {
+		if strings.Contains(destination, part) {
+			binary = destination
+			break
+		}
+	}
+	
+	return
 }
 
-func getAnnounceBinary(platform string) string {
-	switch platform {
-	case "windows":
-		return "announce.exe"
-	case "linux", "darwin":
-		return "announce"
-	default:
-		return ""
+func getAnnounceBinary(cacheDir, version, platform string) (binary string) {
+	pkg, err := FindPackage(cacheDir, version)
+	if err != nil {
+		return
 	}
+	
+	var (
+		paths map[string]string
+		part string
+	)
+	switch platform {
+		case "windows":
+			paths = pkg.Win32Paths
+			part = "announ"
+		case "linux", "darwin":
+			paths = pkg.LinuxPaths
+			part = "announ"
+		default:
+			return
+	}
+	
+	for _, destination := range paths {
+		if strings.Contains(destination, part) {
+			binary = destination
+			break
+		}
+	}
+	
+	return
 }
 
 // MatchesChecksum checks if the file at the given path src is the correct file for the specified

--- a/runtime/run.go
+++ b/runtime/run.go
@@ -45,7 +45,7 @@ func Run(
 		return RunContainer(ctx, cfg, cacheDir, passArgs, output, input)
 	}
 
-	binary := "./" + getServerBinary(cfg.Platform)
+	binary := "./" + getServerBinary(cacheDir, cfg.Version, cfg.Platform)
 	fullPath := filepath.Join(cfg.WorkingDir, binary)
 	print.Verb("starting", binary, "in", cfg.WorkingDir)
 


### PR DESCRIPTION
As I wrote earlier in the issue #288, I have a problem with the incompatibility of binary file names between samp and its adaptation for crmp.

I really hope that this PR solves my problem and you accept it as soon as possible and release a new version of sampctl so that I can use it to its fullest capacity in my projects.