### PR TITLE
Updated default compiler version

### DIFF
--- a/compiler/download.go
+++ b/compiler/download.go
@@ -116,7 +116,7 @@ func GetCompilerPackage(
 	}
 
 	if meta.Tag == "" {
-		meta.Tag = "v3.10.9"
+		meta.Tag = "v3.10.10"
 	} else if meta.Tag[0] != 'v' {
 		meta.Tag = "v" + meta.Tag
 	}

--- a/rook/build_test.go
+++ b/rook/build_test.go
@@ -38,7 +38,7 @@ func TestPackage_Build(t *testing.T) {
 					Entry:          "gamemodes/test.pwn",
 					Output:         "gamemodes/test.amx",
 					Builds: []*types.BuildConfig{
-						{Name: "build", Version: "3.10.9"},
+						{Name: "build", Version: "3.10.10"},
 					},
 				},
 				"build", true, []versioning.DependencyMeta{},
@@ -55,7 +55,7 @@ func TestPackage_Build(t *testing.T) {
 					Entry:          "gamemodes/test.pwn",
 					Output:         "gamemodes/test.amx",
 					Builds: []*types.BuildConfig{
-						{Name: "build", Version: "3.10.9"},
+						{Name: "build", Version: "3.10.10"},
 					},
 				},
 				"build", true,

--- a/types/compiler.go
+++ b/types/compiler.go
@@ -22,7 +22,7 @@ type CompilerVersion string
 func GetBuildConfigDefault() *BuildConfig {
 	return &BuildConfig{
 		Args:    []string{"-d3", "-;+", "-(+", "-\\+", "-Z+"},
-		Version: "3.10.9",
+		Version: "3.10.10",
 	}
 }
 


### PR DESCRIPTION
Updates the default compiler to using 3.10.10 and not 3.10.9

Fixes #329 