### PR TITLE
Added --version as a flag

### DIFF
--- a/commands/app.go
+++ b/commands/app.go
@@ -292,6 +292,9 @@ func Run(args []string, version string) error {
 		}
 		return nil
 	}
+	app.OnUsageError = func(c *cli.Context, err error, isSubcommand bool) error {
+		return err
+	}
 
 	err = app.Run(args)
 	if err != nil {

--- a/commands/app.go
+++ b/commands/app.go
@@ -48,7 +48,7 @@ func Run(args []string, version string) error {
 	app.EnableBashCompletion = true
 
 	cli.VersionFlag = cli.BoolFlag{
-		Name:  "appVersion, V",
+		Name:  "appVersion, V, version",
 		Usage: "sampctl version",
 	}
 


### PR DESCRIPTION
closes #200 

Turns out when you use `cli.VersionFlag` it overrides the default options which are `--V` and `--version` so they need to be re-added.

I also found out that just calling `OnUsageError` and returning the `err` is enough to output the error in a clean way without duplicating.