### PR TITLE
Fixed binary permissions

### DIFF
--- a/compiler/download.go
+++ b/compiler/download.go
@@ -37,7 +37,8 @@ func FromCache(
 		filename,
 		dir,
 		download.ExtractFuncFromName(compiler.Method),
-		compiler.Paths)
+		compiler.Paths,
+		platform)
 	if !hit {
 		return
 	}

--- a/runtime/download.go
+++ b/runtime/download.go
@@ -55,7 +55,7 @@ func FromCache(cacheDir, version, dir, platform string) (hit bool, err error) {
 		}
 	}
 
-	hit, err = download.FromCache(cacheDir, filename, dir, method, paths)
+	hit, err = download.FromCache(cacheDir, filename, dir, method, paths, platform)
 	if !hit || err != nil {
 		return
 	}
@@ -92,10 +92,10 @@ func FromNet(cacheDir, version, dir, platform string) (err error) {
 
 	ok, err := MatchesChecksum(fullPath, platform, cacheDir, version)
 	if err != nil {
-		os.Remove(fullPath);
+		os.Remove(fullPath)
 		return errors.Wrap(err, "failed to match checksum")
 	} else if !ok {
-		os.Remove(fullPath);
+		os.Remove(fullPath)
 		return errors.Errorf("server binary does not match checksum for version %s", version)
 	}
 


### PR DESCRIPTION
closes #158 

This fixes the issue with some binaries not having the correct permissions inside the archive, they are extracted from. My testing with Windows seems to have no effect on the permissions, so I left it out as a check, and only specifically targeted Linux/Mac.

I was able to successfully run the binaries after this change, so I can safely say this is fixed. Though this fix was not exactly described in the issue #158 I think it was related to it's use anyway.
