### PR TITLE
Cleaned up build watcher

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -11,7 +11,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
-	"runtime"
 	"strconv"
 	"strings"
 
@@ -59,8 +58,6 @@ func CompileSource(
 	result types.BuildResult,
 	err error,
 ) {
-	print.Info("Compiling", config.Input, "with compiler version", config.Compiler.Version)
-
 	cmd, err := PrepareCommand(ctx, gh, execDir, cacheDir, platform, config)
 	if err != nil {
 		return
@@ -237,18 +234,10 @@ func CompileWithCommand(
 	}
 
 	if cmdError != nil {
-		if !strings.HasPrefix(cmdError.Error(), "exit status") {
-			if runtime.GOOS == "linux" {
-				print.Erro("if you're on a 64 bit system, you may need to enable 32 bit binaries")
-				print.Erro("you can do this by allowing i386 packages and installing g++-multilib")
-			}
-			err = errors.Wrap(cmdError, "failed to execute compiler")
-			return
-		} else if cmdError.Error() == "exit status 1" {
+		if cmdError.Error() == "exit status 1" {
 			// compilation failed with errors and warnings
 			err = nil
 		} else {
-			// if cmdError.Error() == "signal: killed" || cmdError.Error() == "context canceled"
 			err = cmdError
 			return
 		}

--- a/rook/build.go
+++ b/rook/build.go
@@ -207,11 +207,15 @@ loop:
 			lastEvent = time.Now()
 
 			go func() {
+				defer func() {
+					print.Verb("cancelling existing compiler execution context")
+					cancel()
+					ctxInner, cancel = context.WithCancel(ctx)
+				}()
+
 				if running.Load().(bool) {
 					print.Verb("Build interrupted by file change")
 					cancel()
-					// re-create context and canceler
-					ctxInner, cancel = context.WithCancel(ctx)
 				}
 
 				atomic.AddUint32(&buildNumber, 1)


### PR DESCRIPTION
fixes #363 
fixes #238 

I have cleaned up the build watcher process, and fixed an issue with it exiting early when a build was interrupted. I have tested this quite a bit and found it to work without problems. 

I also cleaned up the output and made it a little easier to see the relevant information.

EDIT: I am still not confident with how I have used context's, I still feel like I am missing something important that could cause issues.