### PR TITLE
Fixed inconsistencies with configs

### DIFF
--- a/types/package.go
+++ b/types/package.go
@@ -49,7 +49,7 @@ type Package struct {
 	Format string `json:"-" yaml:"-"`
 
 	// Inferred metadata, not always explicitly set via JSON/YAML but inferred from the dependency path
-	versioning.DependencyMeta
+	versioning.DependencyMeta `yaml:"-,inline"`
 
 	// Metadata, set by the package author to describe the package
 	Contributors []string `json:"contributors,omitempty" yaml:"contributors,omitempty"` // list of contributors


### PR DESCRIPTION
fixes #364 

This simply fixes the problem of having `DependencyMeta` exposed as a separate struct inside the yaml config, instead of it being silent and having it's children accessible at the root level.