### PR TITLE
separate `resource` from `types`

### DIFF
--- a/resource/resource.go
+++ b/resource/resource.go
@@ -1,4 +1,4 @@
-package types
+package resource
 
 import (
 	"crypto/md5" //nolint
@@ -33,7 +33,7 @@ func (res Resource) Validate() (err error) {
 
 // Path returns a file path for a resource based on a hash of the label
 // nolint
-func (res Resource) Path(pkg Package) (path string) {
+func (res Resource) Path(repo string) (path string) {
 	sum := md5.Sum([]byte(res.Name))
-	return filepath.Join(".resources", fmt.Sprintf("%s-%x", pkg.Repo, sum[:3]))
+	return filepath.Join(".resources", fmt.Sprintf("%s-%x", repo, sum[:3]))
 }

--- a/rook/cache.go
+++ b/rook/cache.go
@@ -87,7 +87,7 @@ func (pcx *PackageContext) EnsureDependenciesCached() (errOuter error) {
 				}
 
 				if len(res.Includes) > 0 {
-					targetPath := filepath.Join(pcx.Package.Vendor, res.Path(currentPackage))
+					targetPath := filepath.Join(pcx.Package.Vendor, res.Path(currentPackage.Repo))
 					pcx.AllIncludePaths = append(pcx.AllIncludePaths, targetPath)
 					print.Verb(prefix, "added target path for resource includes:", targetPath)
 				}

--- a/rook/ensure.go
+++ b/rook/ensure.go
@@ -12,6 +12,7 @@ import (
 	"gopkg.in/eapache/go-resiliency.v1/retrier"
 
 	"github.com/Southclaws/sampctl/print"
+	"github.com/Southclaws/sampctl/resource"
 	"github.com/Southclaws/sampctl/runtime"
 	"github.com/Southclaws/sampctl/types"
 	"github.com/Southclaws/sampctl/util"
@@ -172,9 +173,9 @@ func (pcx *PackageContext) EnsurePackage(meta versioning.DependencyMeta, forceUp
 func (pcx PackageContext) extractResourceDependencies(
 	ctx context.Context,
 	pkg types.Package,
-	res types.Resource,
+	res resource.Resource,
 ) (dir string, err error) {
-	dir = filepath.Join(pcx.Package.Vendor, res.Path(pkg))
+	dir = filepath.Join(pcx.Package.Vendor, res.Path(pkg.Repo))
 	print.Verb(pkg, "installing resource-based dependency", res.Name, "to", dir)
 
 	err = os.MkdirAll(dir, 0700)

--- a/runtime/ensure_plugins_test.go
+++ b/runtime/ensure_plugins_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/Southclaws/sampctl/resource"
 	"github.com/Southclaws/sampctl/types"
 	"github.com/Southclaws/sampctl/util"
 	"github.com/Southclaws/sampctl/versioning"
@@ -113,7 +114,7 @@ func TestGetPluginRemotePackage(t *testing.T) {
 				User: "samp-incognito",
 				Repo: "samp-streamer-plugin",
 			},
-			Resources: []types.Resource{
+			Resources: []resource.Resource{
 				{
 					Name:     "^samp-streamer-plugin-(.*).zip$",
 					Platform: "linux",

--- a/types/package.go
+++ b/types/package.go
@@ -14,6 +14,7 @@ import (
 	"github.com/pkg/errors"
 	"gopkg.in/yaml.v2"
 
+	"github.com/Southclaws/sampctl/resource"
 	"github.com/Southclaws/sampctl/util"
 	"github.com/Southclaws/sampctl/versioning"
 )
@@ -66,7 +67,7 @@ type Package struct {
 	Runtime      *Runtime                      `json:"runtime,omitempty" yaml:"runtime,omitempty"`                   // runtime configuration
 	Runtimes     []*Runtime                    `json:"runtimes,omitempty" yaml:"runtimes,omitempty"`                 // multiple runtime configurations
 	IncludePath  string                        `json:"include_path,omitempty" yaml:"include_path,omitempty"`         // include path within the repository, so users don't need to specify the path explicitly
-	Resources    []Resource                    `json:"resources,omitempty" yaml:"resources,omitempty"`               // list of additional resources associated with the package
+	Resources    []resource.Resource           `json:"resources,omitempty" yaml:"resources,omitempty"`               // list of additional resources associated with the package
 }
 
 func (pkg Package) String() string {


### PR DESCRIPTION
Begins the effort to make the codebase a bit less tangled and flatter.