### PR TITLE
Moved to another configor repo

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -7,8 +7,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/Southclaws/configor"
 	"github.com/google/uuid"
+	"github.com/jinzhu/configor"
 	"github.com/joho/godotenv"
 	"github.com/kr/pretty"
 
@@ -42,6 +42,7 @@ func LoadOrCreateConfig(cacheDir string, verbose bool) (cfg *Config, err error) 
 	configFiles := []string{
 		filepath.Join(cacheDir, "config.json"),
 		filepath.Join(cacheDir, "config.yaml"),
+		filepath.Join(cacheDir, "config.yml"),
 		filepath.Join(cacheDir, "config.toml"),
 	}
 	configFile := ""
@@ -54,7 +55,7 @@ func LoadOrCreateConfig(cacheDir string, verbose bool) (cfg *Config, err error) 
 
 	if configFile != "" {
 		cnfgr := configor.New(&configor.Config{
-			EnvironmentPrefix:    "SAMPCTL",
+			ENVPrefix:            "SAMPCTL",
 			ErrorOnUnmatchedKeys: true,
 		})
 

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/Masterminds/semver v1.5.0
 	github.com/Microsoft/go-winio v0.4.14 // indirect
 	github.com/Netflix/go-expect v0.0.0-20200312175327-da48e75238e2 // indirect
-	github.com/Southclaws/configor v1.0.0
 	github.com/docker/distribution v2.7.1+incompatible // indirect
 	github.com/docker/docker v1.13.1
 	github.com/docker/go-connections v0.4.0
@@ -20,6 +19,7 @@ require (
 	github.com/google/go-querystring v1.0.0 // indirect
 	github.com/google/uuid v1.1.1
 	github.com/hinshun/vt10x v0.0.0-20180809195222-d55458df857c // indirect
+	github.com/jinzhu/configor v1.2.0
 	github.com/joho/godotenv v1.3.0
 	github.com/kr/pretty v0.2.0
 	github.com/kr/pty v1.1.8

--- a/go.sum
+++ b/go.sum
@@ -11,8 +11,6 @@ github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jB
 github.com/Netflix/go-expect v0.0.0-20180615182759-c93bf25de8e8/go.mod h1:oX5x61PbNXchhh0oikYAH+4Pcfw5LKv21+Jnpr6r6Pc=
 github.com/Netflix/go-expect v0.0.0-20200312175327-da48e75238e2 h1:y2avNRjCeJT8b7svzjhKZjsvW5Jki/iAqTBEPJURaUg=
 github.com/Netflix/go-expect v0.0.0-20200312175327-da48e75238e2/go.mod h1:oX5x61PbNXchhh0oikYAH+4Pcfw5LKv21+Jnpr6r6Pc=
-github.com/Southclaws/configor v1.0.0 h1:0bt6XsYs0q3GlK1gOqdjoM4VJj9ePdd/GcNNjzH567A=
-github.com/Southclaws/configor v1.0.0/go.mod h1:LVoYKxkifbFIINnnXwmqeiH4ciRalQNDMwQETyFomTs=
 github.com/alcortesm/tgz v0.0.0-20161220082320-9c5fe88206d7 h1:uSoVVbwJiQipAclBbw+8quDsfcvFjOpI5iCf4p/cqCs=
 github.com/alcortesm/tgz v0.0.0-20161220082320-9c5fe88206d7/go.mod h1:6zEj6s6u/ghQa61ZWa/C2Aw3RkjiTBOix7dkqa1VLIs=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239 h1:kFOfPq6dUM1hTo4JG6LR5AXSUEsOjtdm0kw0FtQtMJA=
@@ -79,6 +77,8 @@ github.com/hinshun/vt10x v0.0.0-20180809195222-d55458df857c/go.mod h1:DqJ97dSdRW
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
+github.com/jinzhu/configor v1.2.0 h1:u78Jsrxw2+3sGbGMgpY64ObKU4xWCNmNRJIjGVqxYQA=
+github.com/jinzhu/configor v1.2.0/go.mod h1:nX89/MOmDba7ZX7GCyU/VIaQ2Ar2aizBl2d3JLF/rDc=
 github.com/joho/godotenv v1.3.0 h1:Zjp+RcGpHhGlrMbJzXTrZZPrWj+1vfm90La1wgB6Bhc=
 github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 h1:Z9n2FFNUXsshfwJMBgNA0RU6/i7WVaAegv3PtuIHPMs=

--- a/pawnpackage/package.go
+++ b/pawnpackage/package.go
@@ -105,6 +105,7 @@ func PackageFromDir(dir string) (pkg Package, err error) {
 	packageDefinitions := []string{
 		filepath.Join(dir, "pawn.json"),
 		filepath.Join(dir, "pawn.yaml"),
+		filepath.Join(dir, "pawn.yml"),
 		filepath.Join(dir, "pawn.toml"),
 	}
 	packageDefinition := ""

--- a/pawnpackage/package.go
+++ b/pawnpackage/package.go
@@ -9,8 +9,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/Southclaws/configor"
 	"github.com/google/go-github/github"
+	"github.com/jinzhu/configor"
 	"github.com/pkg/errors"
 	"gopkg.in/yaml.v2"
 
@@ -124,7 +124,7 @@ func PackageFromDir(dir string) (pkg Package, err error) {
 
 	cnfgr := configor.New(&configor.Config{
 		Environment:          "development",
-		EnvironmentPrefix:    "SAMP",
+		ENVPrefix:            "SAMP",
 		ErrorOnUnmatchedKeys: true,
 	})
 


### PR DESCRIPTION
Due to the recent deletion of the configor on Southclaws repos, the move to an upstream version of the configor seems like the way to go.