### PR TITLE
Merged the runtime fields so values are shared

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/google/go-querystring v1.0.0 // indirect
 	github.com/google/uuid v1.1.1
 	github.com/hinshun/vt10x v0.0.0-20180809195222-d55458df857c // indirect
+	github.com/imdario/mergo v0.3.10
 	github.com/joho/godotenv v1.3.0
 	github.com/kr/pretty v0.2.0
 	github.com/kr/pty v1.1.8

--- a/go.sum
+++ b/go.sum
@@ -74,6 +74,8 @@ github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/hinshun/vt10x v0.0.0-20180616224451-1954e6464174/go.mod h1:DqJ97dSdRW1W22yXSB90986pcOyQ7r45iio1KN2ez1A=
 github.com/hinshun/vt10x v0.0.0-20180809195222-d55458df857c h1:kp3AxgXgDOmIJFR7bIwqFhwJ2qWar8tEQSE5XXhCfVk=
 github.com/hinshun/vt10x v0.0.0-20180809195222-d55458df857c/go.mod h1:DqJ97dSdRW1W22yXSB90986pcOyQ7r45iio1KN2ez1A=
+github.com/imdario/mergo v0.3.10 h1:6q5mVkdH/vYmqngx7kZQTjJ5HRsx+ImorDIEQ+beJgc=
+github.com/imdario/mergo v0.3.10/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=

--- a/rook/build.go
+++ b/rook/build.go
@@ -346,14 +346,21 @@ func GetBuildConfig(pkg pawnpackage.Package, name string) (config *build.Config)
 		if pkg.Build != nil {
 			config = pkg.Build
 		} else {
-			mergo.Merge(pkg.Build, pkg.Builds[0])
 			config = pkg.Builds[0]
+
+			if pkg.Build != nil {
+				mergo.Merge(&config, pkg.Builds[0])
+			}
 		}
 	} else {
 		for _, cfg := range pkg.Builds {
 			if cfg.Name == name {
-				mergo.Merge(cfg, pkg.Build)
 				config = cfg
+
+				if pkg.Build != nil {
+					mergo.Merge(config, pkg.Build)
+				}
+
 				break
 			}
 		}
@@ -361,6 +368,7 @@ func GetBuildConfig(pkg pawnpackage.Package, name string) (config *build.Config)
 
 	if config == nil {
 		if pkg.Build != nil {
+			print.Warn("Build doesn't exist, defaulting to main build")
 			config = pkg.Build
 		} else {
 			print.Warn("No build config called:", name, "using default")

--- a/rook/build.go
+++ b/rook/build.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/fsnotify/fsnotify"
+	"github.com/imdario/mergo"
 	"github.com/pkg/errors"
 
 	"github.com/Southclaws/sampctl/build"
@@ -345,11 +346,13 @@ func GetBuildConfig(pkg pawnpackage.Package, name string) (config *build.Config)
 		if pkg.Build != nil {
 			config = pkg.Build
 		} else {
+			mergo.Merge(pkg.Build, pkg.Builds[0])
 			config = pkg.Builds[0]
 		}
 	} else {
 		for _, cfg := range pkg.Builds {
 			if cfg.Name == name {
+				mergo.Merge(cfg, pkg.Build)
 				config = cfg
 				break
 			}
@@ -357,8 +360,12 @@ func GetBuildConfig(pkg pawnpackage.Package, name string) (config *build.Config)
 	}
 
 	if config == nil {
-		print.Warn("No build config called:", name, "using default")
-		return def
+		if pkg.Build != nil {
+			config = pkg.Build
+		} else {
+			print.Warn("No build config called:", name, "using default")
+			config = def
+		}
 	}
 
 	if config.Version != "" {

--- a/rook/run.go
+++ b/rook/run.go
@@ -221,17 +221,25 @@ func GetRuntimeConfig(pkg pawnpackage.Package, name string) (config run.Runtime,
 		// if the user did not specify a specific runtime config, use the first
 		// otherwise, search for a matching config by name
 		if name == "" {
-			mergo.Merge(pkg.Runtimes[0], pkg.Runtime)
 			config = *pkg.Runtimes[0]
+
+			if pkg.Runtime != nil {
+				mergo.Merge(&config, pkg.Runtime)
+			}
+
 			print.Verb(pkg, "searching", name, "in 'runtimes' list")
 		} else {
 			print.Verb(pkg, "using first config from 'runtimes' list")
 			found := false
 			for _, cfg := range pkg.Runtimes {
 				if cfg.Name == name {
-					mergo.Merge(cfg, pkg.Runtime)
 					config = *cfg
 					found = true
+
+					if pkg.Runtime != nil {
+						mergo.Merge(&config, pkg.Runtime)
+					}
+
 					break
 				}
 			}

--- a/rook/run.go
+++ b/rook/run.go
@@ -11,6 +11,7 @@ import (
 	"sync/atomic"
 	"syscall"
 
+	"github.com/imdario/mergo"
 	"github.com/pkg/errors"
 
 	"github.com/Southclaws/sampctl/build"
@@ -220,6 +221,7 @@ func GetRuntimeConfig(pkg pawnpackage.Package, name string) (config run.Runtime,
 		// if the user did not specify a specific runtime config, use the first
 		// otherwise, search for a matching config by name
 		if name == "" {
+			mergo.Merge(pkg.Runtimes[0], pkg.Runtime)
 			config = *pkg.Runtimes[0]
 			print.Verb(pkg, "searching", name, "in 'runtimes' list")
 		} else {
@@ -227,6 +229,7 @@ func GetRuntimeConfig(pkg pawnpackage.Package, name string) (config run.Runtime,
 			found := false
 			for _, cfg := range pkg.Runtimes {
 				if cfg.Name == name {
+					mergo.Merge(cfg, pkg.Runtime)
 					config = *cfg
 					found = true
 					break


### PR DESCRIPTION
This simply allows you to inherit build/runtime block values, when using the array version of each.

fix #388 