### PR TITLE
Minor fixes

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -55,7 +55,7 @@ func LoadOrCreateConfig(cacheDir string, verbose bool) (cfg *Config, err error) 
 	if configFile != "" {
 		cnfgr := configor.New(&configor.Config{
 			EnvironmentPrefix:    "SAMPCTL",
-			ErrorOnUnmatchedKeys: true,
+			ErrorOnUnmatchedKeys: false,
 		})
 
 		err = cnfgr.Load(cfg, configFile)

--- a/makefile
+++ b/makefile
@@ -1,6 +1,6 @@
 -include .env
 VERSION := $(shell git describe --tags --dirty --always)
-LDFLAGS := -ldflags "-X main.version=$(VERSION) -X"
+LDFLAGS := -ldflags "-X main.version=$(VERSION)"
 
 
 # -

--- a/pawnpackage/package_test.go
+++ b/pawnpackage/package_test.go
@@ -9,11 +9,11 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/go-git/go-git/v5/plumbing/transport"
 	"github.com/google/go-github/github"
 	"github.com/joho/godotenv"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/oauth2"
-	"gopkg.in/src-d/go-git.v4/plumbing/transport"
 
 	"github.com/Southclaws/sampctl/build"
 	"github.com/Southclaws/sampctl/pawnpackage"


### PR DESCRIPTION
Fixes issues with using keys that are not part of the struct, this can be useful for removing keys at a later point and not breaking remote repos.

Fixes an incorrect link to an old version of git go