### PR TITLE
Fixes returning an error when a package does not contain a config file

### DIFF
--- a/pawnpackage/package.go
+++ b/pawnpackage/package.go
@@ -120,7 +120,7 @@ func PackageFromDir(dir string) (pkg Package, err error) {
 	}
 
 	if packageDefinition == "" {
-		err = errors.New("no package definition file (pawn.{json|yaml|toml})")
+		print.Verb("no package definition file (pawn.{json|yaml|toml})")
 		return
 	}
 


### PR DESCRIPTION
fixes #415 the issue with include only packages being ensured multiple times because they don't have a pawn.json file.