### PR TITLE
Fixes sampctl panicking when a folder does not exist when trying to remove it before cloning

### DIFF
--- a/pkgcontext/cache.go
+++ b/pkgcontext/cache.go
@@ -197,7 +197,8 @@ func (pcx PackageContext) ensureRepoExists(
 	repo, err = git.PlainOpen(to)
 	if err != nil {
 		print.Verb("no repo at", to, "-", err, "cloning new copy")
-		if util.Exists(to) {
+
+		if _, err = os.Stat(to); !os.IsNotExist(err) {
 			print.Verb("removing existing folder", to)
 			err = os.RemoveAll(to)
 			if err != nil {


### PR DESCRIPTION
Fixes #402 an issue where sampctl would panic if the repo folder it was ensuring didn't exist when it tried to remove it.
Fixes #244 

