### PR TITLE
fix(ci): binaries is now deprecated for goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -36,8 +36,7 @@ checksum:
 dockers:
   - goos: linux
     goarch: "386"
-    binaries: 
-      - sampctl
+    ids: ['sampctl']
     dockerfile: Dockerfile
     image_templates:
       - "southclaws/sampctl:{{ .Tag }}"


### PR DESCRIPTION
https://goreleaser.com/deprecations/#dockerbinaries

