### PR TITLE
feat: add components:// dependency scheme for open.mp components

### DIFF
--- a/src/pkg/infrastructure/versioning/versioning.go
+++ b/src/pkg/infrastructure/versioning/versioning.go
@@ -87,7 +87,8 @@ func (dm DependencyMeta) Validate() (err error) {
 	// Handle URL-like schemes
 	if dm.Scheme != "" {
 		switch dm.Scheme {
-		case "plugin", "includes", "filterscript":
+		case "plugin", "components", "includes", "filterscript":
+			// Local schemes only need Local path
 			if dm.Local != "" {
 				// Local schemes only need Local path
 				if dm.Local == "" {
@@ -114,7 +115,7 @@ func (dm DependencyMeta) Validate() (err error) {
 	if dm.Repo == "" {
 		return errors.New("dependency meta missing repo")
 	}
-	return
+	return nil
 }
 
 // DependencyOverrides maps original dependency strings to replacement dependency strings
@@ -191,14 +192,14 @@ func ApplyDependencyOverrides(depStr string) string {
 // Returns the overridden dependency string and whether an override was applied
 func ApplyDependencyOverridesWithLogging(depStr string) (string, bool) {
 	overriddenStr := ApplyDependencyOverrides(depStr)
-	
+
 	if overriddenStr != depStr {
 		// An override was applied, log it
 		print.Info(fmt.Sprintf("dependency '%s' was overridden by '%s'", depStr, overriddenStr))
 		print.Verb(fmt.Sprintf("dependency override applied for '%s' -> '%s' (original repository may no longer exist, be deprecated, or have security issues)", depStr, overriddenStr))
 		return overriddenStr, true
 	}
-	
+
 	return depStr, false
 }
 
@@ -214,7 +215,7 @@ var (
 	// MatchDependencyString matches a dependency string such as 'Username/Repository:tag', 'Username/Repository@branch', 'Username/Repository#commit'
 	MatchDependencyString = regexp.MustCompile(`^\/?([a-zA-Z0-9-]+)\/([a-zA-Z0-9-._]+)(?:\/)?([a-zA-Z0-9-_$\[\]{}().,\/]*)?((?:@)|(?:\:)|(?:#))?(.+)?$`)
 	// MatchURLScheme matches URL-like dependency strings such as 'plugin://plugins/name', 'includes://legacy', 'filterscript://user/repo:tag'
-	MatchURLScheme = regexp.MustCompile(`^(plugin|includes|filterscript):\/\/(.+)$`)
+	MatchURLScheme = regexp.MustCompile(`^(plugin|includes|filterscript|component):\/\/(.+)$`)
 )
 
 // Explode splits a dependency string into its component parts and returns a meta object
@@ -414,7 +415,12 @@ func (dm DependencyMeta) IsRemoteScheme() bool {
 
 // IsPlugin returns true if this dependency represents a plugin
 func (dm DependencyMeta) IsPlugin() bool {
-	return dm.Scheme == "plugin"
+	return dm.Scheme == "plugin" || dm.Scheme == "components"
+}
+
+// IsComponent returns true if this dependency represents an Open.MP component
+func (dm DependencyMeta) IsComponent() bool {
+	return dm.Scheme == "components"
 }
 
 // IsIncludes returns true if this dependency represents an includes directory

--- a/src/pkg/package/pkgcontext/url_scheme_test.go
+++ b/src/pkg/package/pkgcontext/url_scheme_test.go
@@ -8,19 +8,19 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/Southclaws/sampctl/src/pkg/package/pawnpackage"
 	"github.com/Southclaws/sampctl/src/pkg/infrastructure/versioning"
+	"github.com/Southclaws/sampctl/src/pkg/package/pawnpackage"
 )
 
 func TestHandleURLSchemeCaching(t *testing.T) {
 	tests := []struct {
-		name              string
-		pcx               *PackageContext
-		meta              versioning.DependencyMeta
-		expectedPlugins   int
-		expectedIncludes  int
-		expectedDeps      int
-		wantErr           bool
+		name             string
+		pcx              *PackageContext
+		meta             versioning.DependencyMeta
+		expectedPlugins  int
+		expectedIncludes int
+		expectedDeps     int
+		wantErr          bool
 	}{
 		{
 			name: "local plugin scheme",
@@ -190,12 +190,12 @@ func TestEnsureURLSchemeDependency(t *testing.T) {
 	defer os.RemoveAll(tmpDir)
 
 	testPath := filepath.Join(tmpDir, "test", "path")
-	
+
 	// Create necessary directories and files for the tests
 	require.NoError(t, os.MkdirAll(filepath.Join(testPath, "plugins"), 0755))
 	require.NoError(t, os.MkdirAll(filepath.Join(testPath, "legacy"), 0755))
 	require.NoError(t, os.MkdirAll(filepath.Join(testPath, "filterscripts"), 0755))
-	
+
 	// Create mock files
 	require.NoError(t, os.WriteFile(filepath.Join(testPath, "plugins", "test"), []byte("mock plugin"), 0644))
 	require.NoError(t, os.WriteFile(filepath.Join(testPath, "legacy", "includes"), []byte("mock include"), 0644))

--- a/src/pkg/runtime/runtime/execute.go
+++ b/src/pkg/runtime/runtime/execute.go
@@ -39,6 +39,12 @@ func PrepareRuntimeDirectory(cacheDir, version, platform, scriptfiles string) (e
 		return errors.Wrap(err, "failed to create plugins directory")
 	}
 
+	// open.mp components dir
+	err = os.MkdirAll(filepath.Join(dir, "components"), 0700)
+	if err != nil {
+		return errors.Wrap(err, "failed to create components directory")
+	}
+
 	scriptfilesTmp := filepath.Join(dir, "scriptfiles")
 	err = os.RemoveAll(scriptfilesTmp)
 	if err != nil {


### PR DESCRIPTION
### Summary

This PR adds first-class support for a new `components://` dependency scheme.

It allows installing open.mp components separately from SA:MP plugins:
- binaries are installed into the `components/` directory
- components are NOT added to the `plugins` runtime list
- fully compatible with existing dependency resolution

### Motivation

open.mp introduces a dedicated `components/` directory for server extensions.
Currently, sampctl treats all binary dependencies as plugins, which causes
open.mp components (e.g. Pawn.CMD-omp) to be installed incorrectly.

This PR aligns sampctl with open.mp runtime expectations.

### What’s included

- New `components://` dependency scheme
- Updated dependency parsing and validation
- Package context support (cache + ensure)
- Runtime installer support
- Tests updated accordingly
- No behavior changes for existing dependencies

### Example usage

```json
{
  "dependencies": [
    "components://katursis/Pawn.CMD:3.4.0-omp"
  ]
}
