### PR TITLE
fix: structuring openmp fields and documenting all runtime fields

### DIFF
--- a/docs/build-configuration-reference.md
+++ b/docs/build-configuration-reference.md
@@ -23,26 +23,73 @@ sampctl build <build-name>
 }
 ```
 
-## Common fields
+## Fields
 
-- `name`: build name (used with `sampctl build <name>`).
-- `input`: override the input `.pwn` file for this build.
-- `output`: override the output `.amx` file for this build.
-- `workingDir`: working directory passed to the compiler.
-- `includes`: extra include paths/files.
-- `constants`: key/value constants passed to the compiler.
+All fields below are supported under a build entry (e.g. `builds.<name>`).
 
-## Compiler selection
+- `name` (string): build name (usually set implicitly by the `builds` map key).
+- `version` (string): optional version label.
+- `workingDir` (string): working directory for compilation.
+- `input` (string): source file to compile.
+- `output` (string): output `.amx` path.
+- `includes` (string[]): include directories passed as `-i` flags.
+- `constants` (object map): constant definitions passed as `-D` flags (key/value).
 
-Under `compiler`:
+### Args and options
 
-- `preset`: `samp` or `openmp` (recommended).
-- `site`/`user`/`repo`/`version`: use a compiler from a Git repo.
-- `path`: use a locally installed compiler.
+You can provide raw arguments and/or structured options:
 
-## Hooks
+- `args` (string[]): raw arguments passed to the compiler (**deprecated**, prefer `options`).
+- `options` (object): structured compiler options (see below).
 
-- `prebuild`: commands to run before compilation.
-- `postbuild`: commands to run after compilation.
+### Plugins (pre-compile commands)
 
-Note: `args` exists for older configs but `options` is preferred.
+- `plugins` (array of string arrays): commands to run before compilation.
+
+Example:
+
+```yaml
+build:
+  plugins:
+    - ["echo", "hello"]
+```
+
+### Compiler selection
+
+- `compiler` (string or object):
+  - string: a preset name (e.g. `samp`, `openmp`).
+  - object: a compiler configuration (see **Compiler config** below).
+
+### Hooks
+
+- `prebuild` (array of string arrays): commands run before compilation.
+- `postbuild` (array of string arrays): commands run after compilation.
+
+## Compiler options (`options`)
+
+These map to Pawn compiler flags:
+
+- `debug_level` (int): `-d<level>`
+- `require_semicolons` (bool): `-;+` / `-;-`
+- `require_parentheses` (bool): `-(+` / `-(-`
+- `require_escape_sequences` (bool): `-\\+` / `-\\-`
+- `compatibility_mode` (bool): `-Z+` / `-Z-`
+- `optimization_level` (int): `-O<level>`
+- `show_listing` (bool): `-l` / `-l-`
+- `show_annotated_assembly` (bool): `-a` / `-a-`
+- `show_error_file` (string): `-e<filename>`
+- `show_warnings` (bool): `-w+` / `-w-`
+- `compact_encoding` (bool): `-C+` / `-C-`
+- `tab_size` (int): `-t<spaces>`
+
+## Compiler config (`compiler` as an object)
+
+If `compiler` is an object, these fields are supported:
+
+- `preset` (string): `samp` or `openmp`.
+- `path` (string): local path to a compiler.
+- `site` / `user` / `repo` / `version` (strings): use a compiler from a Git repo.
+
+## Compiler presets
+
+`sampctl` ships with built-in compiler presets: `samp` and `openmp`.

--- a/docs/package-definition-reference.md
+++ b/docs/package-definition-reference.md
@@ -2,15 +2,7 @@
 
 This page lists the common fields you can use in a `pawn.json` / `pawn.yaml` file.
 
-A minimal example:
-
-```json
-{
-  "entry": "gamemodes/main.pwn",
-  "output": "gamemodes/main.amx",
-  "dependencies": ["pawn-lang/samp-stdlib"]
-}
-```
+For an introduction and a minimal example, see: [Packages](packages.md)
 
 ## Common fields
 

--- a/docs/runtime-configuration-reference.md
+++ b/docs/runtime-configuration-reference.md
@@ -8,33 +8,161 @@ Select a named runtime:
 sampctl run <runtime-name>
 ```
 
+## SA:MP vs open.mp runtimes
+
+`sampctl` supports two runtime types:
+
+- **SA:MP**: generates `server.cfg`.
+- **open.mp**: generates `config.json` (and may also generate a minimal `server.cfg` for legacy plugin compatibility).
+
+Runtime type is determined by:
+
+- `runtime.runtime_type` (explicit override), or
+- auto-detection from `runtime.version` (if it contains `openmp` or `open.mp`, it is treated as open.mp).
+
 ## Common fields
 
 - `name`: runtime name (used with `sampctl run <name>`).
-- `version`: server version to download/run (SA:MP or open.mp).
-- `mode`: how the server is run. Common values: `server`, `main`, `y_testing`.
-- `runtime_type`: `samp` or `openmp` (usually auto-detected from `version`).
+- `version`: runtime version string.
+- `runtime_type`: `samp` or `openmp` (auto-detected from `version` if not set).
+- `mode`: run mode: `server`, `main`, `y_testing`.
+- `rootLink`: (sampctl internal) whether to create a symlink to the package root in the runtime directory.
+- `echo`: (sampctl internal) an optional string written to the start of the generated config.
+
+## Scripts and load lists
+
+- `gamemodes` (string[]): main scripts to run.
+- `filterscripts` (string[]): side scripts to run.
+- `plugins` (string[]): plugin names to load.
+- `components` (string[]): open.mp components to load.
+
+Notes:
+
+- For open.mp, `plugins` are written to `config.json` as `pawn.legacy_plugins` (extensions stripped).
+- For open.mp, `components` are written to `config.json` as `pawn.components` (extensions stripped).
 
 ## Server settings
 
-Most `runtime` keys map directly to `server.cfg` settings (and are also used to generate open.mp `config.json` where applicable), for example:
+All of the following keys are accepted in `runtime`.
 
-- `port`
-- `hostname`
-- `maxplayers`
-- `rcon_password`
-- `lanmode`, `announce`, `query`
+- For **SA:MP**, these map directly to `server.cfg` keys.
+- For **open.mp**, a subset is mapped into `config.json` (documented below); open.mp-only fields are also available directly under `runtime`.
+
+### Core
+
+- `rcon_password` (string)
+- `port` (int)
+- `hostname` (string)
+- `maxplayers` (int)
+- `language` (string)
+- `mapname` (string)
+- `weburl` (string)
+- `gamemodetext` (string)
+
+### Network and technical
+
+- `bind` (string)
+- `password` (string)
+- `announce` (bool)
+- `lanmode` (bool)
+- `query` (bool)
+- `rcon` (bool)
+- `logqueries` (bool)
+- `sleep` (int)
+- `maxnpc` (int)
+
+### Rates and performance
+
+- `stream_rate` (int)
+- `stream_distance` (number)
+- `onfoot_rate` (int)
+- `incar_rate` (int)
+- `weapon_rate` (int)
+- `chatlogging` (bool)
+- `timestamp` (bool)
+- `nosign` (string)
+- `logtimeformat` (string)
+- `messageholelimit` (int)
+- `messageslimit` (int)
+- `ackslimit` (int)
+- `playertimeout` (int)
+- `minconnectiontime` (int)
+- `lagcompmode` (int)
+- `connseedtime` (int)
+- `db_logging` (bool)
+- `db_log_queries` (bool)
+- `conncookies` (bool)
+- `cookielogging` (bool)
+- `output` (bool)
+
+## open.mp `config.json` mapping (what is actually written)
+
+When the runtime is open.mp, `sampctl` generates `config.json` and maps these `runtime` fields:
+
+- `hostname` → `name`
+- `maxplayers` → `max_players`
+- `language` → `language`
+- `password` → `password`
+- `announce` → `announce`
+- `query` → `enable_query`
+- `weburl` → `website`
+- `sleep` → `sleep`
+
+Nested `game`:
+
+- `lagcompmode` → `game.lag_compensation_mode`
+- `mapname` → `game.map`
+- `gamemodetext` → `game.mode`
+
+Nested `network`:
+
+- `port` → `network.port`
+- `bind` → `network.bind`
+- `onfoot_rate` → `network.on_foot_sync_rate`
+- `incar_rate` → `network.in_vehicle_sync_rate`
+- `weapon_rate` → `network.aiming_sync_rate`
+- `stream_rate` → `network.stream_rate`
+- `stream_distance` → `network.stream_radius`
+- `messageholelimit` → `network.message_hole_limit`
+- `messageslimit` → `network.messages_limit`
+- `ackslimit` → `network.acks_limit`
+- `playertimeout` → `network.player_timeout`
+- `minconnectiontime` → `network.minimum_connection_time`
+- `connseedtime` → `network.cookie_reseed_time`
+- `lanmode` → `network.use_lan_mode`
+
+Nested `logging`:
+
+- `output` → `logging.enable`
+- `chatlogging` → `logging.log_chat`
+- `logqueries` → `logging.log_queries`
+- `cookielogging` → `logging.log_cookies`
+- `db_logging` → `logging.log_sqlite`
+- `db_log_queries` → `logging.log_sqlite_queries`
+- `timestamp` → `logging.use_timestamp`
+- `logtimeformat` → `logging.timestamp_format`
+
+Nested `rcon`:
+
+- `rcon` → `rcon.enable`
+- `rcon_password` → `rcon.password`
+
+Nested `pawn`:
+
+- `plugins` → `pawn.legacy_plugins`
+- `components` → `pawn.components`
+- `gamemodes` → `pawn.main_scripts`
+- `filterscripts` → `pawn.side_scripts`
 
 ## Plugins and components
 
-- `plugins` / `components` are the names to load.
-- To download plugins/components, use dependency URL schemes like `plugin://user/repo` and `component://user/repo`.
+- To download plugins/components automatically, prefer dependency URL schemes like `plugin://user/repo` and `component://user/repo`.
 
 See: [Runtime configuration guide](configuration.md)
 
 ## Extra settings
 
-If you need settings that aren’t covered by dedicated fields, use `extra`:
+If you need extra SA:MP `server.cfg` keys (or simple top-level open.mp keys), use `extra`:
 
 ```json
 {
@@ -52,3 +180,36 @@ If you need settings that aren’t covered by dedicated fields, use `extra`:
 For SA:MP, `extra` is written to `server.cfg`.
 
 For open.mp, `extra` is written to `config.json` (and `sampctl` may also generate a minimal `server.cfg` for legacy plugin compatibility).
+
+## open.mp-only fields
+
+open.mp supports additional `config.json` keys that SA:MP does not. These can be set directly under `runtime` and are only used when the runtime is open.mp.
+
+Supported open.mp-only keys:
+
+- `max_bots` (int)
+- `use_dyn_ticks` (bool)
+- `logo` (string)
+- `game` (object)
+- `network` (object)
+- `logging` (object)
+- `pawn` (object)
+- `discord` (object)
+- `banners` (object)
+- `artwork` (object)
+
+Note: `rcon` is a boolean in SA:MP runtime config; to set open.mp-only `config.json.rcon` fields, use `rcon_config` (object), which is merged into `config.json.rcon`.
+
+```yaml
+runtime:
+  version: 1.2.0-openmp
+  hostname: My Server
+  max_bots: 100
+  use_dyn_ticks: false
+  discord:
+    invite: https://discord.gg/example
+  network:
+    public_addr: 127.0.0.1
+  rcon_config:
+    allow_teleport: true
+```

--- a/src/pkg/runtime/run/runtime.go
+++ b/src/pkg/runtime/run/runtime.go
@@ -84,6 +84,23 @@ type Runtime struct {
 
 	// Extra properties for plugins etc
 	Extra map[string]string `required:"0" json:"extra,omitempty" yaml:"extra,omitempty"`
+
+	// open.mp specific properties
+	MaxBots     *int    `ignore:"1" required:"0" json:"max_bots,omitempty"     yaml:"max_bots,omitempty"`
+	UseDynTicks *bool   `ignore:"1" required:"0" json:"use_dyn_ticks,omitempty" yaml:"use_dyn_ticks,omitempty"`
+	Logo        *string `ignore:"1" required:"0" json:"logo,omitempty"         yaml:"logo,omitempty"`
+
+	Game    map[string]any `ignore:"1" required:"0" json:"game,omitempty"     yaml:"game,omitempty"`
+	Network map[string]any `ignore:"1" required:"0" json:"network,omitempty"  yaml:"network,omitempty"`
+	Logging map[string]any `ignore:"1" required:"0" json:"logging,omitempty"  yaml:"logging,omitempty"`
+	Pawn    map[string]any `ignore:"1" required:"0" json:"pawn,omitempty"     yaml:"pawn,omitempty"`
+	Discord map[string]any `ignore:"1" required:"0" json:"discord,omitempty"  yaml:"discord,omitempty"`
+	Banners map[string]any `ignore:"1" required:"0" json:"banners,omitempty"  yaml:"banners,omitempty"`
+	Artwork map[string]any `ignore:"1" required:"0" json:"artwork,omitempty"  yaml:"artwork,omitempty"`
+
+	// rcon is already used by SA:MP as a boolean. this allows setting open.mp-only
+	// `config.json` rcon fields.
+	RCONConfig map[string]any `ignore:"1" required:"0" json:"rcon_config,omitempty" yaml:"rcon_config,omitempty"`
 }
 
 // ContainerConfig is used if the runtime is specified to run inside a container

--- a/src/pkg/runtime/runtime/openmp_fields_test.go
+++ b/src/pkg/runtime/runtime/openmp_fields_test.go
@@ -1,0 +1,53 @@
+package runtime
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+
+	"github.com/Southclaws/sampctl/src/pkg/package/pawnpackage"
+)
+
+func TestPawnYAMLRuntimeOpenMPFieldsArePreserved(t *testing.T) {
+	data := []byte(`preset: openmp
+runtime:
+  discord:
+    invite: https://discord.gg/example
+  rcon_config:
+    allow_teleport: true
+`)
+
+	var pkg pawnpackage.Package
+	require.NoError(t, yaml.Unmarshal(data, &pkg))
+
+	cfg, err := pkg.GetRuntimeConfig("")
+	require.NoError(t, err)
+	require.True(t, cfg.IsOpenMP())
+
+	tmpDir, err := os.MkdirTemp("", "pawnpackage-openmp-fields")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	cfg.WorkingDir = tmpDir
+	cfg.Platform = "linux"
+
+	require.NoError(t, GenerateConfig(&cfg))
+
+	content, err := os.ReadFile(filepath.Join(tmpDir, "config.json"))
+	require.NoError(t, err)
+
+	var parsed map[string]interface{}
+	require.NoError(t, json.Unmarshal(content, &parsed))
+
+	discord, ok := parsed["discord"].(map[string]interface{})
+	require.True(t, ok)
+	require.Equal(t, "https://discord.gg/example", discord["invite"])
+
+	rcon, ok := parsed["rcon"].(map[string]interface{})
+	require.True(t, ok)
+	require.Equal(t, true, rcon["allow_teleport"])
+}


### PR DESCRIPTION
This pull request adds comprehensive support for open.mp-specific runtime configuration fields in both the documentation and codebase. It allows users to specify additional open.mp-only fields in their runtime configuration, ensures these fields are correctly written to `config.json`, and includes thorough documentation and tests to validate this behavior.

**Documentation improvements:**

* Expanded the runtime configuration documentation to clearly list all supported open.mp-only fields, their structure, and how they are mapped into `config.json`. This includes new sections and examples for fields like `max_bots`, `use_dyn_ticks`, `discord`, `network`, `rcon_config`, and more. 
* Clarified the distinction between SA:MP and open.mp runtimes, and updated field descriptions and examples accordingly.

**Codebase enhancements:**

* Extended the `Runtime` struct to include open.mp-specific fields such as `MaxBots`, `UseDynTicks`, `Logo`, and nested maps for `game`, `network`, `logging`, `pawn`, `discord`, `banners`, `artwork`, and `RCONConfig`.
* Updated the open.mp config generation logic to merge these new fields into the output `config.json`, including deep merging for nested maps. Added utility functions for deep merging YAML/JSON structures. 

**Testing:**

* Added and updated tests to verify that open.mp-specific runtime fields are correctly preserved and written to `config.json` in both direct config usage and when loaded from `pawn.yaml`. 

**Other documentation cleanups:**

* Minor improvements and clarifications in build and package definition documentation for consistency and clarity. 

Overall, these changes make it much easier for users to leverage advanced open.mp runtime features in their project configuration and ensure robust handling throughout the toolchain.