### PR TITLE
fix: plugins being treated as components due to the legacy changes.

### DIFF
--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -48,8 +48,8 @@ When a dependency is treated as a plugin/component, `sampctl`:
 3) Picks a single resource by matching `(platform, runtime.version)`.
 4) Downloads the matching GitHub release asset and extracts binaries to:
 
-- `./plugins/` for SA:MP runtimes
-- `./components/` for open.mp runtimes
+- `./plugins/` for `plugin://` dependencies
+- `./components/` for `component://` dependencies
 
 Then it auto-adds the plugin/component name to the runtime config that is generated for the run.
 

--- a/docs/dependency-schemes.md
+++ b/docs/dependency-schemes.md
@@ -35,7 +35,7 @@ What happens:
 
 - The plugin package is ensured like a normal repo dependency.
 - `sampctl` downloads a matching plugin release asset (based on the dependency’s `resources` metadata).
-- The plugin binary is extracted into `./plugins/` (SA:MP) or `./components/` (open.mp runtimes).
+- The plugin binary is extracted into `./plugins/`.
 - The plugin is automatically added to the runtime plugin list.
 
 ## Components (open.mp): `component://user/repo`

--- a/src/pkg/runtime/runtime/ensure_components_test.go
+++ b/src/pkg/runtime/runtime/ensure_components_test.go
@@ -1,0 +1,59 @@
+package runtime
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/Southclaws/sampctl/src/pkg/infrastructure/fs"
+	"github.com/Southclaws/sampctl/src/pkg/infrastructure/versioning"
+	"github.com/Southclaws/sampctl/src/pkg/runtime/run"
+)
+
+func TestEnsureComponentsExtractToComponentsDir(t *testing.T) {
+	cfg := run.Runtime{
+		Platform:    "linux",
+		Version:     "v1.0.0-openmp",
+		RuntimeType: run.RuntimeTypeOpenMP,
+		PluginDeps: []versioning.DependencyMeta{{
+			Scheme: "component",
+			User:   "katursis",
+			Repo:   "Pawn.RakNet",
+			Tag:    "1.6.0-omp",
+		}},
+	}
+
+	cfg.WorkingDir = filepath.Join("./tests/ensure", "Pawn.RakNet-component-linux-openmp")
+	_ = os.MkdirAll(cfg.WorkingDir, 0o700)
+
+	err := EnsurePlugins(context.Background(), gh, &cfg, "./tests/cache", true)
+	assert.NoError(t, err)
+
+	// It should install binaries into ./components
+	componentsDir := filepath.Join(cfg.WorkingDir, "components")
+	pluginsDir := filepath.Join(cfg.WorkingDir, "plugins")
+
+	assert.True(t, fs.Exists(componentsDir))
+	assert.True(t, fs.Exists(pluginsDir))
+
+	entries, readErr := os.ReadDir(componentsDir)
+	assert.NoError(t, readErr)
+
+	foundBinary := false
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if filepath.Ext(name) == ".so" || filepath.Ext(name) == ".dll" {
+			foundBinary = true
+			break
+		}
+	}
+	assert.True(t, foundBinary, "expected at least one component binary in ./components")
+
+	assert.NotEmpty(t, cfg.Components)
+}

--- a/src/pkg/runtime/runtime/ensure_plugins_test.go
+++ b/src/pkg/runtime/runtime/ensure_plugins_test.go
@@ -20,60 +20,69 @@ func TestEnsurePlugins(t *testing.T) {
 		cfg run.Runtime
 	}
 	tests := []struct {
-		name        string
-		args        args
-		wantFiles   []string
-		wantPlugins []run.Plugin
-		wantErr     bool
+		name           string
+		args           args
+		wantFiles      []string
+		wantPlugins    []run.Plugin
+		wantComponents []run.Plugin
+		wantErr        bool
 	}{
 		{"streamer-linux", args{
 			run.Runtime{
 				Platform:   "linux",
 				PluginDeps: []versioning.DependencyMeta{{User: "samp-incognito", Repo: "samp-streamer-plugin", Tag: "v2.9.2"}},
 			},
-		}, []string{"plugins/streamer.so"}, []run.Plugin{"streamer"}, false},
+		}, []string{"plugins/streamer.so"}, []run.Plugin{"streamer"}, nil, false},
+		{"streamer-linux-openmp", args{
+			run.Runtime{
+				Platform:    "linux",
+				Version:     "v1.0.0-openmp",
+				RuntimeType: run.RuntimeTypeOpenMP,
+				PluginDeps:  []versioning.DependencyMeta{{User: "samp-incognito", Repo: "samp-streamer-plugin", Tag: "v2.9.2"}},
+			},
+		}, []string{"plugins/streamer.so"}, []run.Plugin{"streamer"}, nil, false},
 		{"streamer-windows", args{
 			run.Runtime{
 				Platform:   "windows",
 				PluginDeps: []versioning.DependencyMeta{{User: "samp-incognito", Repo: "samp-streamer-plugin", Tag: "v2.9.2"}},
 			},
-		}, []string{"plugins/streamer.dll"}, []run.Plugin{"streamer"}, false},
+		}, []string{"plugins/streamer.dll"}, []run.Plugin{"streamer"}, nil, false},
 		{"mysql-linux", args{
 			run.Runtime{
 				Platform:   "linux",
 				PluginDeps: []versioning.DependencyMeta{{User: "pBlueG", Repo: "SA-MP-MySQL", Tag: "R41-4"}},
 			},
-		}, []string{"plugins/mysql.so"}, []run.Plugin{"mysql"}, false},
+		}, []string{"plugins/mysql.so"}, []run.Plugin{"mysql"}, nil, false},
 		{"mysql-windows", args{
 			run.Runtime{
 				Platform:   "windows",
 				PluginDeps: []versioning.DependencyMeta{{User: "pBlueG", Repo: "SA-MP-MySQL", Tag: "R41-4"}},
 			},
-		}, []string{"plugins/mysql.dll"}, []run.Plugin{"mysql"}, false},
+		}, []string{"plugins/mysql.dll"}, []run.Plugin{"mysql"}, nil, false},
 		{"bitmapper-linux", args{
 			run.Runtime{
 				Platform:   "linux",
 				PluginDeps: []versioning.DependencyMeta{{User: "Southclaws", Repo: "samp-bitmapper", Tag: "0.2.1"}},
 			},
-		}, []string{"plugins/bitmapper.so"}, []run.Plugin{"bitmapper"}, false},
+		}, []string{"plugins/bitmapper.so"}, []run.Plugin{"bitmapper"}, nil, false},
 		{"bitmapper-windows", args{
 			run.Runtime{
 				Platform:   "windows",
 				PluginDeps: []versioning.DependencyMeta{{User: "Southclaws", Repo: "samp-bitmapper", Tag: "0.2.1"}},
 			},
-		}, []string{"plugins/bitmapper.dll"}, []run.Plugin{"bitmapper"}, false},
+		}, []string{"plugins/bitmapper.dll"}, []run.Plugin{"bitmapper"}, nil, false},
 		{"PawnPlus-linux", args{
 			run.Runtime{
 				Platform:   "linux",
 				PluginDeps: []versioning.DependencyMeta{{User: "IllidanS4", Repo: "PawnPlus", Tag: "v0.5"}},
 			},
-		}, []string{"plugins/PawnPlus.so"}, []run.Plugin{"PawnPlus"}, false},
+		}, []string{"plugins/PawnPlus.so"}, []run.Plugin{"PawnPlus"}, nil, false},
 		{"PawnPlus-windows", args{
 			run.Runtime{
 				Platform:   "windows",
 				PluginDeps: []versioning.DependencyMeta{{User: "IllidanS4", Repo: "PawnPlus", Tag: "v0.5"}},
 			},
-		}, []string{"plugins/PawnPlus.dll"}, []run.Plugin{"PawnPlus"}, false},
+		}, []string{"plugins/PawnPlus.dll"}, []run.Plugin{"PawnPlus"}, nil, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -104,6 +113,7 @@ func TestEnsurePlugins(t *testing.T) {
 			}
 
 			assert.Equal(t, tt.wantPlugins, tt.args.cfg.Plugins)
+			assert.Equal(t, tt.wantComponents, tt.args.cfg.Components)
 		})
 	}
 }

--- a/src/pkg/runtime/runtime/generate.go
+++ b/src/pkg/runtime/runtime/generate.go
@@ -13,7 +13,7 @@ import (
 func adjustForOS(dir, os string, cfg *run.Runtime) {
 	if os == "linux" || os == "darwin" {
 		if len(cfg.Plugins) > 0 {
-			actualPlugins := getPlugins(filepath.Join(dir, getPluginDirectory(cfg)), cfg.Platform)
+			actualPlugins := getPlugins(filepath.Join(dir, getPluginDirectory()), cfg.Platform)
 
 			for i, declared := range cfg.Plugins {
 				ext := filepath.Ext(string(declared))

--- a/src/pkg/runtime/runtime/plugin_directory_test.go
+++ b/src/pkg/runtime/runtime/plugin_directory_test.go
@@ -26,7 +26,7 @@ func TestGetPluginDirectory(t *testing.T) {
 			name:        "open.mp runtime auto-detect",
 			version:     "v1.0.0-openmp",
 			runtimeType: run.RuntimeTypeAuto,
-			expectedDir: "components",
+			expectedDir: "plugins",
 		},
 		{
 			name:        "Explicit SA-MP runtime",
@@ -38,7 +38,7 @@ func TestGetPluginDirectory(t *testing.T) {
 			name:        "Explicit open.mp runtime",
 			version:     "custom-version",
 			runtimeType: run.RuntimeTypeOpenMP,
-			expectedDir: "components",
+			expectedDir: "plugins",
 		},
 	}
 
@@ -50,7 +50,7 @@ func TestGetPluginDirectory(t *testing.T) {
 				WorkingDir:  "/test/dir",
 			}
 
-			result := getPluginDirectory(cfg)
+			result := getPluginDirectory()
 			assert.Equal(t, tt.expectedDir, result)
 
 			// Also test the full path


### PR DESCRIPTION
This pull request refactors the handling of plugin and component dependencies in the runtime package to simplify directory selection and clarify the extraction logic. The main change is that plugin binaries are always extracted to the `plugins` directory, while component binaries are extracted to the `components` directory only for `component://` dependencies. The update also improves test coverage for these changes and updates documentation for consistency.

**Runtime logic and directory handling:**

* Refactored `getPluginDirectory` to always return `"plugins"`, removing conditional logic based on runtime type. Directory selection for components is now handled explicitly when the dependency scheme is `component`. (`src/pkg/runtime/runtime/ensure_plugins.go`

**Test suite improvements:**

* Added a new test `TestEnsureComponentsExtractToComponentsDir` to verify that component binaries are correctly extracted to the `components` directory and that the runtime's `Components` list is populated. (`src/pkg/runtime/runtime/ensure_components_test.go` 
* Updated existing tests to check both `Plugins` and `Components` lists in the runtime configuration, ensuring correctness for both plugin and component dependencies.
* Adjusted tests for `getPluginDirectory` to reflect the new logic, expecting `"plugins"` for all cases. (`src/pkg/runtime/runtime/plugin_directory_test.go` 

**Miscellaneous improvements:**

* Improved extraction logic in `EnsureVersionedPlugin` to avoid overwriting plugin/include destinations when extracting additional files. (`src/pkg/runtime/runtime/ensure_plugins.go` 
* Updated documentation to clarify the difference between plugin and component extraction directories and to use consistent terminology.