### PR TITLE
fix(runtime): add website alias and exclude for open.mp config.json

### DIFF
--- a/src/pkg/runtime/config/runtime.go
+++ b/src/pkg/runtime/config/runtime.go
@@ -86,9 +86,13 @@ type Runtime struct {
 	Extra map[string]string `required:"0" json:"extra,omitempty" yaml:"extra,omitempty"`
 
 	// open.mp specific properties
-	MaxBots     *int    `ignore:"1" required:"0" json:"max_bots,omitempty"     yaml:"max_bots,omitempty"`
-	UseDynTicks *bool   `ignore:"1" required:"0" json:"use_dyn_ticks,omitempty" yaml:"use_dyn_ticks,omitempty"`
-	Logo        *string `ignore:"1" required:"0" json:"logo,omitempty"         yaml:"logo,omitempty"`
+	MaxBots     *int     `ignore:"1" required:"0" json:"max_bots,omitempty"     yaml:"max_bots,omitempty"`
+	UseDynTicks *bool    `ignore:"1" required:"0" json:"use_dyn_ticks,omitempty" yaml:"use_dyn_ticks,omitempty"`
+	Logo        *string  `ignore:"1" required:"0" json:"logo,omitempty"         yaml:"logo,omitempty"`
+	// open.mp-native alias for weburl; takes precedence when both are set
+	Website     *string  `ignore:"1" required:"0" json:"website,omitempty"      yaml:"website,omitempty"`
+	// components to exclude from the generated pawn.components list
+	Exclude     []Plugin `ignore:"1" required:"0" json:"exclude,omitempty"      yaml:"exclude,omitempty"`
 
 	Game    map[string]any `ignore:"1" required:"0" json:"game,omitempty"     yaml:"game,omitempty"`
 	Network map[string]any `ignore:"1" required:"0" json:"network,omitempty"  yaml:"network,omitempty"`

--- a/src/pkg/runtime/config_openmp.go
+++ b/src/pkg/runtime/config_openmp.go
@@ -198,7 +198,9 @@ func (o *openMPConfig) generate(cfg *run.Runtime) (err error) {
 	if cfg.Query != nil {
 		config.EnableQuery = *cfg.Query
 	}
-	if cfg.Weburl != nil && *cfg.Weburl != "open.mp" {
+	if cfg.Website != nil && *cfg.Website != "" {
+		config.Website = *cfg.Website
+	} else if cfg.Weburl != nil && *cfg.Weburl != "open.mp" {
 		config.Website = *cfg.Weburl
 	}
 	if cfg.Sleep != nil {
@@ -327,15 +329,25 @@ func (o *openMPConfig) generate(cfg *run.Runtime) (err error) {
 	}
 
 	if len(cfg.Components) > 0 {
-		components := make([]string, len(cfg.Components))
-		for i, component := range cfg.Components {
+		excluded := make(map[string]bool, len(cfg.Exclude))
+		for _, exc := range cfg.Exclude {
+			excStr := strings.TrimSuffix(string(exc), filepath.Ext(string(exc)))
+			excluded[excStr] = true
+		}
+
+		components := make([]string, 0, len(cfg.Components))
+		for _, component := range cfg.Components {
 			componentStr := string(component)
 			if strings.HasSuffix(componentStr, ".so") || strings.HasSuffix(componentStr, ".dll") {
 				componentStr = strings.TrimSuffix(componentStr, filepath.Ext(componentStr))
 			}
-			components[i] = componentStr
+			if !excluded[componentStr] {
+				components = append(components, componentStr)
+			}
 		}
-		config.Pawn.Components = components
+		if len(components) > 0 {
+			config.Pawn.Components = components
+		}
 	}
 
 	if len(cfg.Gamemodes) > 0 {

--- a/src/pkg/runtime/config_test.go
+++ b/src/pkg/runtime/config_test.go
@@ -354,3 +354,117 @@ func TestOpenMPConfigGenerateWithoutExtraServerCfg(t *testing.T) {
 	serverCfgPath := filepath.Join(tmpDir, "server.cfg")
 	assert.NoFileExists(t, serverCfgPath)
 }
+
+func TestOpenMPWebsiteKey(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "openmp_website_test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	website := "example.com"
+	cfg := &run.Runtime{
+		WorkingDir: tmpDir,
+		Platform:   "linux",
+		Version:    "1.2.0-openmp",
+		Mode:       run.Server,
+		Website:    &website,
+	}
+
+	require.NoError(t, GenerateConfig(cfg))
+
+	content, err := os.ReadFile(filepath.Join(tmpDir, "config.json"))
+	require.NoError(t, err)
+
+	var config map[string]any
+	require.NoError(t, json.Unmarshal(content, &config))
+	assert.Equal(t, "example.com", config["website"])
+}
+
+func TestOpenMPWebsiteKeyTakesPrecedenceOverWeburl(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "openmp_website_weburl_test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	website := "explicit.com"
+	weburl := "legacy.com"
+	cfg := &run.Runtime{
+		WorkingDir: tmpDir,
+		Platform:   "linux",
+		Version:    "1.2.0-openmp",
+		Mode:       run.Server,
+		Website:    &website,
+		Weburl:     &weburl,
+	}
+
+	require.NoError(t, GenerateConfig(cfg))
+
+	content, err := os.ReadFile(filepath.Join(tmpDir, "config.json"))
+	require.NoError(t, err)
+
+	var config map[string]any
+	require.NoError(t, json.Unmarshal(content, &config))
+	assert.Equal(t, "explicit.com", config["website"])
+}
+
+func TestOpenMPExcludeComponents(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "openmp_exclude_test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	cfg := &run.Runtime{
+		WorkingDir: tmpDir,
+		Platform:   "linux",
+		Version:    "1.2.0-openmp",
+		Mode:       run.Server,
+		Components: []run.Plugin{"pawnraknet", "pawn-memory", "samp-node"},
+		Exclude:    []run.Plugin{"pawn-memory"},
+	}
+
+	require.NoError(t, GenerateConfig(cfg))
+
+	content, err := os.ReadFile(filepath.Join(tmpDir, "config.json"))
+	require.NoError(t, err)
+
+	var config map[string]any
+	require.NoError(t, json.Unmarshal(content, &config))
+
+	pawn, ok := config["pawn"].(map[string]any)
+	require.True(t, ok)
+
+	components, ok := pawn["components"].([]any)
+	require.True(t, ok)
+	assert.Contains(t, components, "pawnraknet")
+	assert.Contains(t, components, "samp-node")
+	assert.NotContains(t, components, "pawn-memory")
+}
+
+func TestOpenMPExcludeComponentsWithExtensions(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "openmp_exclude_ext_test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	// exclude list and components list use different extension formats
+	cfg := &run.Runtime{
+		WorkingDir: tmpDir,
+		Platform:   "linux",
+		Version:    "1.2.0-openmp",
+		Mode:       run.Server,
+		Components: []run.Plugin{"pawnraknet.so", "pawn-memory"},
+		Exclude:    []run.Plugin{"pawnraknet"},
+	}
+
+	require.NoError(t, GenerateConfig(cfg))
+
+	content, err := os.ReadFile(filepath.Join(tmpDir, "config.json"))
+	require.NoError(t, err)
+
+	var config map[string]any
+	require.NoError(t, json.Unmarshal(content, &config))
+
+	pawn, ok := config["pawn"].(map[string]any)
+	require.True(t, ok)
+
+	components, ok := pawn["components"].([]any)
+	require.True(t, ok)
+	assert.Contains(t, components, "pawn-memory")
+	assert.NotContains(t, components, "pawnraknet")
+}


### PR DESCRIPTION
Fixes issues from #619.

## Changes

- Add `website` as a yaml key in `samp.yaml` (open.mp-native alias for `weburl`). When both are set, `website` takes precedence.
- Add `exclude` field to filter specific components from the generated `pawn.components` list in `config.json`. Normalises `.so`/`.dll` extensions on both sides so matching works regardless of format.

## Notes

- `chat_input_filter` and other game-level fields can already be set via the generic `game:` map in `samp.yaml` (e.g. `game: {chat_input_filter: 0}`)
- Float precision for structured fields was already handled by typed `float64` fields

Issues: #619