### PR TITLE
fix(download): correct asset error message and honor context in retry

### DIFF
--- a/src/pkg/infrastructure/download/download.go
+++ b/src/pkg/infrastructure/download/download.go
@@ -233,7 +233,9 @@ func FromNetWithClient(ctx context.Context, client HTTPDoer, location, cachePath
 					lastErr = errors.Errorf("content has unexpected content type %s", t)
 					err = lastErr
 					if attempt < maxAttempts {
-						fromNetSleep(backoff(attempt))
+						if sleepErr := sleepRetryBackoff(ctx, backoff(attempt)); sleepErr != nil {
+							return "", sleepErr
+						}
 						continue
 					}
 					return "", err
@@ -308,7 +310,7 @@ func ReleaseAssetByPattern(request ReleaseAssetRequest) (filename, tag string, e
 func ReleaseAssetByPatternWithAPI(request ReleaseAssetAPIRequest) (filename, tag string, err error) {
 	var (
 		asset  *github.ReleaseAsset
-		assets = make([]string, 1)
+		assets = make([]string, 0)
 	)
 
 	var release *github.RepositoryRelease


### PR DESCRIPTION
two bugs in download.go:

asset list error message the slice was initialized with make([]string, 1), which caused it to always contain an empty entry at the beginning; it was fixed by changing it to make([]string, 0)

retry ignoring context the retry branch for “unexpected content-type” used fromNetSleep directly; it was fixed by replacing it with sleepRetryBackoff(ctx, ...) so that timeout or cancellation is properly respected, just like in the other retry branches